### PR TITLE
Set Access-Control-Allow-Origin", "*"

### DIFF
--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -280,6 +280,7 @@ void WebServer::_prepareHeader(String& response, int code, const char* content_t
       sendHeader("Transfer-Encoding","chunked");
     }
     sendHeader("Connection", "close");
+    sendHeader("Access-Control-Allow-Origin", "*");
 
     response += _responseHeaders;
     response += "\r\n";


### PR DESCRIPTION
Sets Access-Control-Allow-Origin", "*", which brings this function's behavior inline with that of the ESP8266 equivalent.